### PR TITLE
Fix compilation warnings

### DIFF
--- a/include/upa/idna/idna.h
+++ b/include/upa/idna/idna.h
@@ -11,6 +11,7 @@
 #include "nfc.h"
 #include <algorithm>
 #include <string>
+#include <type_traits> // std::make_unsigned
 
 namespace upa {
 namespace idna {
@@ -65,6 +66,7 @@ constexpr char ascii_to_lower_char(CharT c) noexcept {
 // IDNA map and normalize NFC
 template <typename CharT>
 inline bool map(std::u32string& mapped, const CharT* input, const CharT* input_end, Option options, bool is_to_ascii) {
+    using UCharT = typename std::make_unsigned<CharT>::type;
     using namespace upa::idna::util;
 
     // P1 - Map
@@ -73,7 +75,7 @@ inline bool map(std::u32string& mapped, const CharT* input, const CharT* input_e
         mapped.reserve(input_end - input);
         if (has(options, Option::UseSTD3ASCIIRules)) {
             for (const auto* it = input; it != input_end; ++it) {
-                const auto cp = *it;
+                const auto cp = static_cast<UCharT>(*it);
                 switch (asciiData[cp]) {
                 case AC_VALID:
                     mapped.push_back(cp);

--- a/src/idna.cpp
+++ b/src/idna.cpp
@@ -319,7 +319,7 @@ bool to_ascii_mapped(std::string& domain, const std::u32string& mapped, Option o
                     domain.push_back('-');
                     domain.append(alabel);
                 } else {
-                    domain.append(label, label_end);
+                    // ignore label if it cannot be punycode encoded and record an error
                     ok = false; // punycode error
                 }
             } else {

--- a/test/convert_utf.h
+++ b/test/convert_utf.h
@@ -1,0 +1,33 @@
+#ifndef UPA_CONVERT_UTF_H
+#define UPA_CONVERT_UTF_H
+
+#include <cstdint>
+
+
+// Modified version of the U8_APPEND_UNSAFE macro in utf8.h from ICU
+//
+// It converts code_point to UTF-8 bytes sequence and calls appendByte function for each byte.
+// It assumes a valid code point (https://infra.spec.whatwg.org/#scalar-value).
+
+template <class OutputIt>
+inline void append_utf8(OutputIt outit, char32_t code_point) {
+    if (code_point <= 0x7f) {
+        *outit++ = static_cast<std::uint8_t>(code_point);
+    } else {
+        if (code_point <= 0x7ff) {
+            *outit++ = static_cast<std::uint8_t>((code_point >> 6) | 0xc0);
+        } else {
+            if (code_point <= 0xffff) {
+                *outit++ = static_cast<std::uint8_t>((code_point >> 12) | 0xe0);
+            } else {
+                *outit++ = static_cast<std::uint8_t>((code_point >> 18) | 0xf0);
+                *outit++ = static_cast<std::uint8_t>(((code_point >> 12) & 0x3f) | 0x80);
+            }
+            *outit++ = static_cast<std::uint8_t>(((code_point >> 6) & 0x3f) | 0x80);
+        }
+        *outit++ = static_cast<std::uint8_t>((code_point & 0x3f) | 0x80);
+    }
+}
+
+
+#endif // UPA_CONVERT_UTF_H

--- a/test/idna_lib_upa.cpp
+++ b/test/idna_lib_upa.cpp
@@ -2,35 +2,28 @@
 // Distributed under the BSD-style license that can be
 // found in the LICENSE file.
 //
+#include "convert_utf.h"
 #include "idna_lib.h"
-
-// conversion
-#include <algorithm>
-#include <codecvt>
-#include <locale>    // std::wstring_convert
 
 // IDNA (UTS46)
 #include "upa/idna.h"
 
+// conversion
+#include <algorithm>
+#include <iterator>
+
+
 namespace {
-#if defined(_MSC_VER) && _MSC_VER >= 1900 && _MSC_VER < 1920
-    // for VS 2015 and VS 2017 
-    // https://stackoverflow.com/q/32055357
-    static std::wstring_convert<std::codecvt_utf8<uint32_t>, uint32_t> conv32;
 
-    inline std::string utf32_to_bytes(const std::u32string& input) {
-        return conv32.to_bytes(
-            reinterpret_cast<const uint32_t*>(input.data()),
-            reinterpret_cast<const uint32_t*>(input.data() + input.length()));
+    inline std::string utf8_from_utf32(const std::u32string& input) {
+        std::string str_utf8;
+        auto iter = std::back_inserter(str_utf8);
+        for (auto cp : input)
+            append_utf8(iter, cp);
+        return str_utf8;
     }
-#else
-    static std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv32;
 
-    inline std::string utf32_to_bytes(const std::u32string& input) {
-        return conv32.to_bytes(input);
-    }
-#endif
-}
+} // namespace
 
 
 namespace idna_lib {
@@ -88,7 +81,7 @@ namespace idna_lib {
 #endif
 
         // to utf-8
-        output = utf32_to_bytes(domain);
+        output = utf8_from_utf32(domain);
 
         return res;
     }

--- a/test/test-idna.cpp
+++ b/test/test-idna.cpp
@@ -25,7 +25,7 @@ inline std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, T
 int run_idna_tests_v2(const char* file_name);
 int run_punycode_tests(const char* file_name);
 static std::string get_column8(const std::string& line, std::size_t& pos);
-static std::u16string get_column16(const std::string& line, std::size_t& pos);
+//static std::u16string get_column16(const std::string& line, std::size_t& pos);
 static std::u32string get_column32(const std::string& line, std::size_t& pos);
 static bool is_error(const std::string& col);
 static bool is_error_of_to_unicode(const std::string& col);
@@ -273,9 +273,9 @@ static std::string get_column8(const std::string& line, std::size_t& pos) {
     return get_column<char>(line, pos);
 }
 
-static std::u16string get_column16(const std::string& line, std::size_t& pos) {
-    return get_column<char16_t>(line, pos);
-}
+//static std::u16string get_column16(const std::string& line, std::size_t& pos) {
+//    return get_column<char16_t>(line, pos);
+//}
 
 static std::u32string get_column32(const std::string& line, std::size_t& pos) {
     return get_column<char32_t>(line, pos);
@@ -367,16 +367,18 @@ int run_punycode_tests(const char* file_name)
                 // test
                 if (case_name.empty()) case_name = line;
                 ddt.test_case(case_name.c_str(), [&](DataDrivenTest::TestCase& tc) {
-                    bool ok;
+                    bool ok{};
 
                     // encode to punycode
                     std::string out_encoded; // punycode::encode(..) appends
                     ok = upa::idna::punycode::encode(out_encoded, inp_source.data(), inp_source.data() + inp_source.length()) == upa::idna::punycode::status::success;
+                    tc.assert_equal(true, ok, "punycode::encode success");
                     tc.assert_equal(inp_encoded8, out_encoded, "punycode::encode");
 
                     // decode from punycode
                     std::u32string out_decoded; // punycode::decode(..) appends
                     ok = upa::idna::punycode::decode(out_decoded, inp_encoded.data(), inp_encoded.data() + inp_encoded.length()) == upa::idna::punycode::status::success;
+                    tc.assert_equal(true, ok, "punycode::decode success");
                     tc.assert_equal(inp_source, out_decoded, "punycode::decode");
                 });
             }

--- a/test/test-utf.cpp
+++ b/test/test-utf.cpp
@@ -4,36 +4,12 @@
 //
 #include "upa/idna/iterate_utf.h"
 #include "ddt/DataDrivenTest.hpp"
+#include "convert_utf.h"
 #include <iterator>
 
 template <class T>
 inline bool is_surrogate(T ch) {
     return (ch & 0xFFFFF800) == 0xD800;
-}
-
-// Modified version of the U8_APPEND_UNSAFE macro in utf8.h from ICU
-//
-// It converts code_point to UTF-8 bytes sequence and calls appendByte function for each byte.
-// It assumes a valid code point (https://infra.spec.whatwg.org/#scalar-value).
-
-template <class OutputIt>
-inline void append_utf8(OutputIt outit, std::uint32_t code_point) {
-    if (code_point <= 0x7f) {
-        *outit++ = static_cast<uint8_t>(code_point);
-    } else {
-        if (code_point <= 0x7ff) {
-            *outit++ = static_cast<uint8_t>((code_point >> 6) | 0xc0);
-        } else {
-            if (code_point <= 0xffff) {
-                *outit++ = static_cast<uint8_t>((code_point >> 12) | 0xe0);
-            } else {
-                *outit++ = static_cast<uint8_t>((code_point >> 18) | 0xf0);
-                *outit++ = static_cast<uint8_t>(((code_point >> 12) & 0x3f) | 0x80);
-            }
-            *outit++ = static_cast<uint8_t>(((code_point >> 6) & 0x3f) | 0x80);
-        }
-        *outit++ = static_cast<uint8_t>((code_point & 0x3f) | 0x80);
-    }
 }
 
 


### PR DESCRIPTION
* Fix `codecvt... is deprecated` compilation warning
* Fix Clang warnings
* Fix: ignore label if it cannot be punycode encoded and record an error
* Fix MSVC warning (use custom `std::string` append fucntion)
