### PR TITLE
Add option to build as shared library

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: clang++ C++17
+          - name: clang++ C++17 shared-lib
             cxx_compiler: clang++
             cxx_standard: 17
-            cmake_options: ""
+            cmake_options: "-DBUILD_SHARED_LIBS=ON"
 
           - name: clang++ C++20
             cxx_compiler: clang++

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -14,20 +14,20 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: clang++ C++17
+          - name: clang++ C++17 shared-lib
             cxx_compiler: clang++
             cxx_standard: 17
-            cmake_options: ""
+            cmake_options: "-DBUILD_SHARED_LIBS=ON"
 
           - name: clang++ C++20
             cxx_compiler: clang++
             cxx_standard: 20
             cmake_options: ""
 
-          - name: g++ C++17
+          - name: g++ C++17 shared-lib
             cxx_compiler: g++
             cxx_standard: 17
-            cmake_options: ""
+            cmake_options: "-DBUILD_SHARED_LIBS=ON"
 
           - name: g++ C++20
             cxx_compiler: g++

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -20,11 +20,11 @@ jobs:
             cxx_standard: 17
             cmake_options: ""
 
-          - name: VS 2022 C++17
+          - name: VS 2022 C++17 shared-lib
             os: windows-2022
             generator: "Visual Studio 17 2022"
             cxx_standard: 17
-            cmake_options: ""
+            cmake_options: "-DBUILD_SHARED_LIBS=ON"
 
           - name: VS 2022 C++20
             os: windows-2022
@@ -32,11 +32,11 @@ jobs:
             cxx_standard: 20
             cmake_options: ""
 
-          - name: VS 2022 Clang C++17
+          - name: VS 2022 Clang C++17 shared-lib
             os: windows-2022
             generator: "Visual Studio 17 2022"
             cxx_standard: 17
-            cmake_options: "-T ClangCL"
+            cmake_options: "-T ClangCL -DBUILD_SHARED_LIBS=ON"
 
           - name: VS 2022 Clang C++20
             os: windows-2022

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ if (NOT upa_idna_version_h MATCHES "[ \t]+UPA_IDNA_VERSION[ \t]+\"([0-9]+(\.[0-9
 endif()
 set(UPA_IDNA_VERSION ${CMAKE_MATCH_1})
 message(STATUS "Upa IDNA version: ${UPA_IDNA_VERSION}")
+# Create SOVERSION from major and minor version numbers
+string(REGEX MATCH "^[0-9]+\.[0-9]+" UPA_IDNA_SOVERSION ${UPA_IDNA_VERSION})
+message(STATUS "Upa IDNA SOVERSION: ${UPA_IDNA_SOVERSION}")
 
 # Project settings
 project(test_idna VERSION ${UPA_IDNA_VERSION} LANGUAGES CXX)
@@ -18,29 +21,41 @@ if (NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
-include_directories(
-  include
-)
+# Library settings
 
-add_executable(test-idna
-  test/test-idna.cpp
-  test/idna_lib_upa.cpp
+add_library(upa_idna
   src/idna.cpp
   src/idna_table.cpp
   src/nfc.cpp
   src/nfc_table.cpp
-  src/punycode.cpp
-)
+  src/punycode.cpp)
+target_include_directories(upa_idna PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+if (BUILD_SHARED_LIBS)
+  target_compile_definitions(upa_idna PRIVATE UPA_LIB_EXPORT
+    INTERFACE UPA_LIB_IMPORT)
+endif()
+set_target_properties(upa_idna PROPERTIES
+  VERSION ${UPA_IDNA_VERSION}
+  SOVERSION ${UPA_IDNA_SOVERSION}
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN ON)
+
+# Test targets
+
+add_executable(test-idna
+  test/test-idna.cpp
+  test/idna_lib_upa.cpp)
+target_link_libraries(test-idna PRIVATE upa_idna)
 
 add_executable(test-nfc
-  test/test-nfc.cpp
-  src/nfc.cpp
-  src/nfc_table.cpp
-)
+  test/test-nfc.cpp)
+target_link_libraries(test-nfc PRIVATE upa_idna)
 
 add_executable(test-utf
-  test/test-utf.cpp
-)
+  test/test-utf.cpp)
+target_link_libraries(test-utf PRIVATE upa_idna)
 
 # Testing
 

--- a/include/upa/idna/config.h
+++ b/include/upa/idna/config.h
@@ -1,0 +1,25 @@
+// Copyright 2025 Rimas Misevičius
+// Distributed under the BSD-style license that can be
+// found in the LICENSE file.
+//
+#ifndef UPA_IDNA_CONFIG_H
+#define UPA_IDNA_CONFIG_H
+
+// Define UPA_IDNA_API macro to mark symbols for export/import
+// when compiling as shared library
+#if defined (UPA_LIB_EXPORT) || defined (UPA_LIB_IMPORT)
+# ifdef _MSC_VER
+#  ifdef UPA_LIB_EXPORT
+#   define UPA_IDNA_API __declspec(dllexport)
+#  else
+#   define UPA_IDNA_API __declspec(dllimport)
+#  endif
+# elif defined(__clang__) || defined(__GNUC__)
+#  define UPA_IDNA_API __attribute__((visibility ("default")))
+# endif
+#endif
+#ifndef UPA_IDNA_API
+# define UPA_IDNA_API
+#endif
+
+#endif // UPA_IDNA_CONFIG_H

--- a/include/upa/idna/idna.h
+++ b/include/upa/idna/idna.h
@@ -6,6 +6,7 @@
 #define UPA_IDNA_IDNA_H
 
 #include "bitmask_operators.hpp"
+#include "config.h" // IWYU pragma: export
 #include "idna_table.h"
 #include "idna_version.h" // IWYU pragma: export
 #include "iterate_utf.h"
@@ -129,8 +130,8 @@ inline bool map(std::u32string& mapped, const CharT* input, const CharT* input_e
     return true;
 }
 
-bool to_ascii_mapped(std::string& domain, const std::u32string& mapped, Option options);
-bool to_unicode_mapped(std::u32string& domain, const std::u32string& mapped, Option options);
+UPA_IDNA_API bool to_ascii_mapped(std::string& domain, const std::u32string& mapped, Option options);
+UPA_IDNA_API bool to_unicode_mapped(std::u32string& domain, const std::u32string& mapped, Option options);
 
 } // namespace detail
 

--- a/include/upa/idna/idna_table.h
+++ b/include/upa/idna/idna_table.h
@@ -5,6 +5,7 @@
 #ifndef UPA_IDNA_IDNA_TABLE_H
 #define UPA_IDNA_IDNA_TABLE_H
 
+#include "config.h" // IWYU pragma: export
 #include <cstddef>
 #include <cstdint>
 
@@ -50,13 +51,13 @@ const std::uint32_t uni_spec_range1 = 0xE0100;
 const std::uint32_t uni_spec_range2 = 0xE01EF;
 const std::uint32_t uni_spec_value = 0x20000;
 
-extern const std::uint32_t uni_data[];
-extern const std::uint16_t uni_data_index[];
-extern const char32_t uni_chars_to[];
+extern UPA_IDNA_API const std::uint32_t uni_data[];
+extern UPA_IDNA_API const std::uint16_t uni_data_index[];
+extern UPA_IDNA_API const char32_t uni_chars_to[];
 
 extern const std::uint8_t comp_disallowed_std3[3];
 
-extern const std::uint8_t ascii_data[128];
+extern UPA_IDNA_API const std::uint8_t ascii_data[128];
 // END-GENERATED
 
 

--- a/include/upa/idna/nfc.h
+++ b/include/upa/idna/nfc.h
@@ -1,20 +1,21 @@
-// Copyright 2024 Rimas Misevičius
+// Copyright 2024-2025 Rimas Misevičius
 // Distributed under the BSD-style license that can be
 // found in the LICENSE file.
 //
 #ifndef UPA_IDNA_NFC_H
 #define UPA_IDNA_NFC_H
 
+#include "config.h" // IWYU pragma: export
 #include <string>
 
 namespace upa::idna {
 
 
-void compose(std::u32string& str);
-void canonical_decompose(std::u32string& str);
+UPA_IDNA_API void compose(std::u32string& str);
+UPA_IDNA_API void canonical_decompose(std::u32string& str);
 
-void normalize_nfc(std::u32string& str);
-bool is_normalized_nfc(const char32_t* first, const char32_t* last);
+UPA_IDNA_API void normalize_nfc(std::u32string& str);
+UPA_IDNA_API bool is_normalized_nfc(const char32_t* first, const char32_t* last);
 
 
 } // namespace upa::idna

--- a/include/upa/idna/punycode.h
+++ b/include/upa/idna/punycode.h
@@ -1,10 +1,11 @@
-// Copyright 2017-2024 Rimas Misevičius
+// Copyright 2017-2025 Rimas Misevičius
 // Distributed under the BSD-style license that can be
 // found in the LICENSE file.
 //
 #ifndef UPA_IDNA_PUNYCODE_H
 #define UPA_IDNA_PUNYCODE_H
 
+#include "config.h" // IWYU pragma: export
 #include <string>
 
 namespace upa::idna::punycode {
@@ -16,8 +17,8 @@ enum class status {
     overflow = 3    // Wider integers needed to process input.
 };
 
-status encode(std::string& output, const char32_t* first, const char32_t* last);
-status decode(std::u32string& output, const char32_t* first, const char32_t* last);
+UPA_IDNA_API status encode(std::string& output, const char32_t* first, const char32_t* last);
+UPA_IDNA_API status decode(std::u32string& output, const char32_t* first, const char32_t* last);
 
 } // namespace upa::idna::punycode
 

--- a/unitool/unitool-idna.cpp
+++ b/unitool/unitool-idna.cpp
@@ -357,7 +357,7 @@ void make_mapping_table(const std::filesystem::path& data_path) {
 
     std::vector<int> blockIndex;
 
-    fout_head << "extern const std::uint32_t uni_data[];\n";
+    fout_head << "extern UPA_IDNA_API const std::uint32_t uni_data[];\n";
     fout << "const std::uint32_t uni_data[] = {";
     {
         OutputFmt outfmt(fout, 100);
@@ -387,7 +387,7 @@ void make_mapping_table(const std::filesystem::path& data_path) {
     if (index_levels == 1) {
         // Vieno lygio indeksas
         const char* sztype = getUIntType(blockIndex);
-        fout_head << "extern const " << sztype << " uni_data_index[];\n";
+        fout_head << "extern UPA_IDNA_API const " << sztype << " uni_data_index[];\n";
         fout << "const " << sztype << " uni_data_index[] = {";
         {
             OutputFmt outfmt(fout, 100);
@@ -445,7 +445,7 @@ void make_mapping_table(const std::filesystem::path& data_path) {
     }
 
     const char* sztype = getCharType<char_to_t>();
-    fout_head << "extern const " << sztype << " uni_chars_to[];\n";
+    fout_head << "extern UPA_IDNA_API const " << sztype << " uni_chars_to[];\n";
     fout << "const " << sztype << " uni_chars_to[] = {";
     {
         OutputFmt outfmt(fout, 100);
@@ -461,7 +461,7 @@ void make_mapping_table(const std::filesystem::path& data_path) {
 
     // ASCII data
     fout_head << '\n';
-    fout_head << "extern const std::uint8_t ascii_data[128];\n";
+    fout_head << "extern UPA_IDNA_API const std::uint8_t ascii_data[128];\n";
     fout << "const std::uint8_t ascii_data[128] = {";
     {
         OutputFmt outfmt(fout, 100);


### PR DESCRIPTION
The `BUILD_SHARED_LIBS=ON` CMake option can be used to build as a shared library.