### PR TITLE
Add `Option::FailFast`

### DIFF
--- a/include/upa/idna/idna.h
+++ b/include/upa/idna/idna.h
@@ -27,6 +27,8 @@ enum class Option {
     CheckJoiners      = 0x0020,
     // ASCII optimization
     InputASCII        = 0x1000,
+    // On error return imediatly, without further processing
+    FailFast          = 0x2000,
 };
 
 template<>
@@ -34,7 +36,7 @@ struct enable_bitmask_operators<Option> : public std::true_type {};
 
 // Returns the options for to_ascii and to_unicode functions
 constexpr Option domain_options(bool be_strict, bool is_input_ascii) noexcept {
-    // https://url.spec.whatwg.org/#concept-domain-to-ascii
+    // https://url.spec.whatwg.org/#domain-parser-toascii
     // https://url.spec.whatwg.org/#concept-domain-to-unicode
     // Note. The to_unicode ignores Option::VerifyDnsLength
     auto options = Option::CheckBidi | Option::CheckJoiners;
@@ -57,11 +59,11 @@ constexpr bool has(Option option, const Option value) noexcept {
 // IDNA map and normalize to NFC
 
 template <typename CharT>
-bool map(std::u32string& mapped, const CharT* input, const CharT* input_end, Option options, bool is_to_ascii);
+bool map(std::u32string& mapped, const CharT* input, const CharT* input_end, Option options);
 
-extern template UPA_IDNA_API bool map(std::u32string&, const char*, const char*, Option, bool);
-extern template UPA_IDNA_API bool map(std::u32string&, const char16_t*, const char16_t*, Option, bool);
-extern template UPA_IDNA_API bool map(std::u32string&, const char32_t*, const char32_t*, Option, bool);
+extern template UPA_IDNA_API bool map(std::u32string&, const char*, const char*, Option);
+extern template UPA_IDNA_API bool map(std::u32string&, const char16_t*, const char16_t*, Option);
+extern template UPA_IDNA_API bool map(std::u32string&, const char32_t*, const char32_t*, Option);
 
 // Performs ToASCII on IDNA-mapped and normalized to NFC input
 UPA_IDNA_API bool to_ascii_mapped(std::string& domain, const std::u32string& mapped, Option options);
@@ -77,7 +79,8 @@ UPA_EXPORT_BEGIN
 ///
 /// See: https://www.unicode.org/reports/tr46/#ToASCII
 ///
-/// @param[out] domain buffer to store result string
+/// @param[out] domain buffer to store result string. Stored
+///   result is valid if the function returns `true`.
 /// @param[in]  input source domain string
 /// @param[in]  input_end the end of source domain string
 /// @param[in]  options
@@ -87,16 +90,19 @@ inline bool to_ascii(std::string& domain, const CharT* input, const CharT* input
     // P1 - Map and further processing
     std::u32string mapped;
     domain.clear();
+    const auto opt = options | Option::FailFast;
     return
-        detail::map(mapped, input, input_end, options, true) &&
-        detail::to_ascii_mapped(domain, mapped, options);
+        detail::map(mapped, input, input_end, opt) &&
+        detail::to_ascii_mapped(domain, mapped, opt);
 }
 
 /// @brief Implements the Unicode IDNA ToUnicode
 ///
 /// See: https://www.unicode.org/reports/tr46/#ToUnicode
 ///
-/// @param[out] domain buffer to store result string
+/// @param[out] domain buffer to store result string. Result is appended to the buffer. The
+///  stored result is valid regardless of the returned value, unless `Option::FailFast` is
+///  specified; in that case, the stored result is valid only if the returned value is `true`.
 /// @param[in]  input source domain string
 /// @param[in]  input_end the end of source domain string
 /// @param[in]  options
@@ -105,7 +111,9 @@ template <typename CharT>
 inline bool to_unicode(std::u32string& domain, const CharT* input, const CharT* input_end, Option options) {
     // P1 - Map and further processing
     std::u32string mapped;
-    detail::map(mapped, input, input_end, options, false);
+    if (!detail::map(mapped, input, input_end, options) &&
+        detail::has(options, Option::FailFast))
+        return false;
     return detail::to_unicode_mapped(domain, mapped, options);
 }
 

--- a/src/idna.cpp
+++ b/src/idna.cpp
@@ -317,7 +317,7 @@ constexpr char ascii_to_lower_char(CharT c) noexcept {
 // IDNA map and normalize to NFC
 
 template <typename CharT>
-bool map(std::u32string& mapped, const CharT* input, const CharT* input_end, Option options, bool is_to_ascii) {
+bool map(std::u32string& mapped, const CharT* input, const CharT* input_end, Option options) {
     using UCharT = std::make_unsigned_t<CharT>;
 
     // P1 - Map
@@ -336,7 +336,7 @@ bool map(std::u32string& mapped, const CharT* input, const CharT* input_end, Opt
                     break;
                 default:
                     // util::AC_DISALLOWED_STD3
-                    if (is_to_ascii)
+                    if (has(options, Option::FailFast))
                         return false;
                     mapped.push_back(cp);
                 }
@@ -380,7 +380,7 @@ bool map(std::u32string& mapped, const CharT* input, const CharT* input_end, Opt
                 // normalized: 0x3C, 0x3D, and 0x3E (see upa::idna::util::comp_disallowed_std3).
                 // So, for other disallowed characters, failure can be returned here, avoiding the
                 // normalization step.
-                if (is_to_ascii &&
+                if (has(options, Option::FailFast) &&
                     ((value & util::CP_DISALLOWED_STD3) == 0 || cp > 0x3E || cp < 0x3C))
                     return false;
                 mapped.push_back(cp);
@@ -396,9 +396,9 @@ bool map(std::u32string& mapped, const CharT* input, const CharT* input_end, Opt
 }
 
 // The `map` function template instantiations
-template bool map(std::u32string&, const char*, const char*, Option, bool);
-template bool map(std::u32string&, const char16_t*, const char16_t*, Option, bool);
-template bool map(std::u32string&, const char32_t*, const char32_t*, Option, bool);
+template bool map(std::u32string&, const char*, const char*, Option);
+template bool map(std::u32string&, const char16_t*, const char16_t*, Option);
+template bool map(std::u32string&, const char32_t*, const char32_t*, Option);
 
 // Performs ToASCII on IDNA-mapped and normalized to NFC input
 


### PR DESCRIPTION
It is always set for `to_ascii`. It may be useful to optimize `to_unicode` when an output string is only needed if the input is IDNA-valid.